### PR TITLE
Clone largest

### DIFF
--- a/generics/src/main.rs
+++ b/generics/src/main.rs
@@ -1,21 +1,13 @@
-//  The prompt says: Another way we could implement largest is
-// for the function to return a reference to a T value in the slice.
-// If we change the return type to &T instead of T, thereby changing
-//  the body of the function to return a reference, we wouldn’t need
-// the Clone or Copy trait bounds and we could avoid heap allocations.
-// So I cleared the Copy here and tried everything I could think of to return
-// a reference to &T but nothing even lets me compile the code.
-// What am i doing wrong?
 fn largest<T: PartialOrd>(list: &[T]) -> &T {
-  let mut largest = list[0];
+  let mut largest = &list[0];
 
-  for &item in list {
+  for item in list {
       if item > largest {
-          largest = item;
+          largest = &item;
       }
   }
 
-  largest
+  &largest
 }
 
 fn main() {

--- a/generics/src/main.rs
+++ b/generics/src/main.rs
@@ -1,4 +1,12 @@
-fn largest<T: PartialOrd + Copy>(list: &[T]) -> T {
+//  The prompt says: Another way we could implement largest is
+// for the function to return a reference to a T value in the slice.
+// If we change the return type to &T instead of T, thereby changing
+//  the body of the function to return a reference, we wouldn’t need
+// the Clone or Copy trait bounds and we could avoid heap allocations.
+// So I cleared the Copy here and tried everything I could think of to return
+// a reference to &T but nothing even lets me compile the code.
+// What am i doing wrong?
+fn largest<T: PartialOrd>(list: &[T]) -> &T {
   let mut largest = list[0];
 
   for &item in list {


### PR DESCRIPTION
This implements the feature where I don't need the clone method because I just return a reference to the item in memory rather than an actual local variable.

This would have been easier to solve were I using rust-analyzer https://github.com/rust-analyzer/rust-analyzer

Level up!